### PR TITLE
Release 3.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,24 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Placeholder for upcoming changes.
 
 ---
+## [3.0.0] - 2025-08-23
+### Added
+- New **Tug-of-War** clock (progress bar/rope) with fixed central scrimmage line.
+- Outcome A/B titles above the bar; editable tab title driving live canvas title.
+- Outcome A/B fill color pickers (defaults: Outcome A = Green `#2ECC71`, Outcome B = Red `#E74C3C`).
 
+### Changed
+- Tug-of-War **Reset** now restores the rope to center **and** resets Outcome A/B colors to defaults.
+- Title in the Tug-of-War canvas updates immediately as the Tab Title text changes.
+
+### Fixed
+- Removed the “Scrimmage Line” label text under the rope (kept the vertical line).
+
+### Notes
+- Save/Load extended with a new tab type `"tug"`; existing sessions remain compatible.
+
+
+---
 ## [2.2.0] - 2025-08-23
 
 ### Added

--- a/progress_clocks.py
+++ b/progress_clocks.py
@@ -3,7 +3,7 @@
 Progress Clocks Application
 """
 
-__version__ = "2.2.0"
+__version__ = "3.0.0"
 
 
 import json
@@ -1907,6 +1907,9 @@ class TugOfWarFrame(ttk.Frame):
         ttk.Label(top, text="Tab Title:").pack(side="left")
         ent = ttk.Entry(top, textvariable=self.title_var, width=28, justify="center")
         ent.pack(side="left", padx=(6, 12))
+        # Live‑update the bar title as the Tab Title changes
+        self.title_var.trace_add("write", lambda *_: self.draw())
+        ent.bind("<KeyRelease>", lambda e: self.draw())
 
         ttk.Label(top, text="Length (steps):").pack(side="left", padx=(0, 6))
         step_box = ttk.Combobox(top, state="readonly", values=self.STEP_CHOICES, width=6, textvariable=self.steps)
@@ -2074,9 +2077,6 @@ class TugOfWarFrame(ttk.Frame):
 
         # Scrimmage line overlay (fixed at true center)
         c.create_line(cx, top_y+6, cx, bottom_y-6, fill=colors["fg"], width=2)
-
-        # Label the center (optional, subtle)
-        c.create_text(cx, mid_y + bar_h/2 + 10, text="Scrimmage Line", fill=colors["fg"], font=("Arial", 9))
 
     # ---------- Persistence ----------
     def to_dict(self) -> dict:


### PR DESCRIPTION
## [3.0.0] - 2025-08-23
### Added
- New **Tug-of-War** clock (progress bar/rope) with fixed central scrimmage line.
- Outcome A/B titles above the bar; editable tab title driving live canvas title.
- Outcome A/B fill color pickers (defaults: Outcome A = Green `#2ECC71`, Outcome B = Red `#E74C3C`).

### Changed
- Tug-of-War **Reset** now restores the rope to center **and** resets Outcome A/B colors to defaults.
- Title in the Tug-of-War canvas updates immediately as the Tab Title text changes.

### Fixed
- Removed the “Scrimmage Line” label text under the rope (kept the vertical line).

### Notes
- Save/Load extended with a new tab type `"tug"`; existing sessions remain compatible.